### PR TITLE
apply system_info(ets_limit) patch from otp

### DIFF
--- a/erts/doc/src/erl.xml
+++ b/erts/doc/src/erl.xml
@@ -524,7 +524,7 @@
 	<p>Calling <c>erlang:halt/1</c> with a string argument will still
 	produce a crash dump.</p>
       </item>
-      <tag><c><![CDATA[+e Number]]></c></tag>
+      <tag><marker id="+e"><c><![CDATA[+e Number]]></c></marker></tag>
       <item>
         <p>Set max number of ETS tables.</p>
       </item>

--- a/erts/doc/src/erlang.xml
+++ b/erts/doc/src/erlang.xml
@@ -5500,6 +5500,9 @@ ok
       <name name="system_info" arity="1" clause_i="49"/>
       <name name="system_info" arity="1" clause_i="50"/>
       <name name="system_info" arity="1" clause_i="51"/>
+      <name name="system_info" arity="1" clause_i="52"/>
+      <name name="system_info" arity="1" clause_i="53"/>
+      <name name="system_info" arity="1" clause_i="54"/>
       <fsummary>Information about the system</fsummary>
       <desc>
         <p>Returns various information about the current system
@@ -5576,6 +5579,13 @@ ok
               information see the <seealso marker="erts:crash_dump">"How to interpret the Erlang crash dumps"</seealso>
               chapter in the ERTS User's Guide.</p>
           </item>
+          <tag><marker id="system_info_dist_buf_busy_limit"><c>dist_buf_busy_limit</c></marker></tag>
+          <item>
+            <p>Returns the value of the distribution buffer busy limit
+	    in bytes. This limit can be set on startup by passing the
+	    <seealso marker="erts:erl#+zdbbl">+zdbbl</seealso> command line
+	    flag to <c>erl</c>.</p>
+          </item>
           <tag><c>dist_ctrl</c></tag>
           <item>
             <p>Returns a list of tuples
@@ -5622,12 +5632,14 @@ ok
 	      The return value will always be <c>false</c> since
 	      the elib_malloc allocator has been removed.</p>
           </item>
-          <tag><marker id="system_info_dist_buf_busy_limit"><c>dist_buf_busy_limit</c></marker></tag>
+          <tag><c>ets_limit</c></tag>
           <item>
-            <p>Returns the value of the distribution buffer busy limit
-	    in bytes. This limit can be set on startup by passing the
-	    <seealso marker="erts:erl#+zdbbl">+zdbbl</seealso> command line
-	    flag to <c>erl</c>.</p>
+            <p>Returns the maximum number of ETS tables allowed. This limit
+              can be increased on startup by passing the <seealso
+              marker="erts:erl#+e">+e</seealso> command line flag to
+              <c>erl</c> or by setting the environment variable
+              <c>ERL_MAX_ETS_TABLES</c> before starting the Erlang runtime
+              system.</p>
           </item>
           <tag><c>fullsweep_after</c></tag>
           <item>

--- a/erts/emulator/beam/erl_bif_info.c
+++ b/erts/emulator/beam/erl_bif_info.c
@@ -2636,6 +2636,9 @@ BIF_RETTYPE system_info_1(BIF_ALIST_1)
 
 	BIF_RET(res);
     }
+    else if (ERTS_IS_ATOM_STR("ets_limit",BIF_ARG_1)) {
+        BIF_RET(make_small(erts_db_get_max_tabs()));
+    }
 
     BIF_ERROR(BIF_P, BADARG);
 }

--- a/erts/emulator/beam/erl_db.c
+++ b/erts/emulator/beam/erl_db.c
@@ -3811,6 +3811,13 @@ erts_db_foreach_offheap(DbTable *tb,
     tb->common.meth->db_foreach_offheap(tb, func, arg);
 }
 
+/* retrieve max number of ets tables */
+Uint
+erts_db_get_max_tabs()
+{
+    return db_max_tabs;
+}
+
 /*
  * For testing of meta tables only.
  *

--- a/erts/emulator/beam/erl_db.h
+++ b/erts/emulator/beam/erl_db.h
@@ -79,6 +79,8 @@ extern erts_smp_atomic_t erts_ets_misc_mem_size;
 
 Eterm erts_ets_colliding_names(Process*, Eterm name, Uint cnt);
 
+Uint erts_db_get_max_tabs(void);
+
 #endif
 
 #if defined(ERTS_WANT_DB_INTERNAL__) && !defined(ERTS_HAVE_DB_INTERNAL__)

--- a/erts/preloaded/src/erlang.erl
+++ b/erts/preloaded/src/erlang.erl
@@ -2099,13 +2099,14 @@ tuple_to_list(_Tuple) ->
          (creation) -> integer();
          (debug_compiled) -> boolean();
          (dist) -> binary();
+         (dist_buf_busy_limit) -> non_neg_integer();
          (dist_ctrl) -> {Node :: node(),
                          ControllingEntity :: port() | pid()};
          (driver_version) -> string();
 	 (dynamic_trace) -> none | dtrace | systemtap;
          (dynamic_trace_probes) -> boolean();
          (elib_malloc) -> false;
-         (dist_buf_busy_limit) -> non_neg_integer();
+         (ets_limit) -> pos_integer();
          (fullsweep_after) -> {fullsweep_after, non_neg_integer()};
          (garbage_collection) -> [{atom(), integer()}];
          (heap_sizes) -> [non_neg_integer()];


### PR DESCRIPTION
Pick up `erlang:system_info(ets_limit)` support from R16B03 from [Erlang/OTP commit 75a79e65](https://github.com/erlang/otp/commit/75a79e6547fd66c2194d6f488c30ad888a715f4b).
