### PR TITLE
Block SSLv3 explicitly

### DIFF
--- a/lib/ssl/src/tls_record.erl
+++ b/lib/ssl/src/tls_record.erl
@@ -259,8 +259,11 @@ supported_protocol_versions([_|_] = Vsns) ->
 -spec is_acceptable_version(tls_version(), Supported :: [tls_version()]) -> boolean().
 %%     
 %% Description: ssl version 2 is not acceptable security risks are too big.
+%%              ssl version 3 is also now considered insecure.
 %% 
 %%--------------------------------------------------------------------
+is_acceptable_version({3,0}) ->
+    false;
 is_acceptable_version({N,_}) 
   when N >= ?LOWEST_MAJOR_SUPPORTED_VERSION ->
     true;


### PR DESCRIPTION
Intended for a basho7 with the next 2.0 point release. Kill SSLv3 dead to block POODLE attacks.
