### PR TITLE
Legitimize version string

### DIFF
--- a/erts/vsn.mk
+++ b/erts/vsn.mk
@@ -18,7 +18,7 @@
 #
 
 VSN = 5.10.3
-SYSTEM_VSN = R16B02-basho6
+SYSTEM_VSN = R16B02_basho6
 
 # Port number 4365 in 4.2
 # Port number 4366 in 4.3


### PR DESCRIPTION
Having a dash in our custom version of Erlang was breaking some automated tools. This'll make life much easier and not cause spurious warnings if/when customers try to follow our directions for building OTP.
