### PR TITLE
Add support for FreeBSD closefrom

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -1099,7 +1099,7 @@ fi
 
 AC_SUBST(ERTS_BUILD_SMP_EMU)
 
-AC_CHECK_FUNCS([posix_fadvise])
+AC_CHECK_FUNCS([posix_fadvise closefrom])
 AC_CHECK_HEADERS([linux/falloc.h])
 dnl * Old glibcs have broken fallocate64(). Make sure not to use it.
 AC_CACHE_CHECK([whether fallocate() works],i_cv_fallocate_works,[

--- a/erts/emulator/sys/unix/erl_child_setup.c
+++ b/erts/emulator/sys/unix/erl_child_setup.c
@@ -89,8 +89,12 @@ main(int argc, char *argv[])
 
     if (sscanf(argv[CS_ARGV_FD_CR_IX], "%d:%d", &from, &to) != 2)
 	return 1;
+#if defined(HAVE_CLOSEFROM)
+    closefrom(from);
+#else
     for (i = from; i <= to; i++)
 	(void) close(i);
+#endif
 
     if (!(argv[CS_ARGV_WD_IX][0] == '.' && argv[CS_ARGV_WD_IX][1] == '\0')
 	&& chdir(argv[CS_ARGV_WD_IX]) < 0)


### PR DESCRIPTION
Add closefrom support for FreeBSD.

Implemented in OTP 17:
https://github.com/erlang/otp/blob/OTP-17.0/erts/configure.in#L1166
https://github.com/erlang/otp/blob/OTP-17.0/erts/emulator/sys/unix/erl_child_setup.c#L114-L119

and WhatsApp's R16b01:
https://github.com/reedr/otp/commit/b3420b3632c94d4c4869e88f057ca659aa513aea