### PR TITLE
Use closefrom(2) when available in child_setup

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -1099,7 +1099,7 @@ fi
 
 AC_SUBST(ERTS_BUILD_SMP_EMU)
 
-AC_CHECK_FUNCS([posix_fadvise])
+AC_CHECK_FUNCS([posix_fadvise closefrom])
 AC_CHECK_HEADERS([linux/falloc.h])
 dnl * Old glibcs have broken fallocate64(). Make sure not to use it.
 AC_CACHE_CHECK([whether fallocate() works],i_cv_fallocate_works,[

--- a/erts/emulator/sys/unix/erl_child_setup.c
+++ b/erts/emulator/sys/unix/erl_child_setup.c
@@ -89,8 +89,14 @@ main(int argc, char *argv[])
 
     if (sscanf(argv[CS_ARGV_FD_CR_IX], "%d:%d", &from, &to) != 2)
 	return 1;
-    for (i = from; i <= to; i++)
+
+#if defined(HAVE_CLOSEFROM)
+    closefrom(from);
+#else
+    for (i = from; i <= to; i++) {
 	(void) close(i);
+    }
+#endif /* HAVE_CLOSEFROM */
 
     if (!(argv[CS_ARGV_WD_IX][0] == '.' && argv[CS_ARGV_WD_IX][1] == '\0')
 	&& chdir(argv[CS_ARGV_WD_IX]) < 0)


### PR DESCRIPTION
On FreeBSD we have more than 1 million syscalls with kern.maxfiles: 2096124

Backport from otp-17.