### PR TITLE
Change erlang:make_ref/0 to use atomic counter on 64-bit platforms

### DIFF
--- a/erts/doc/src/notes.xml
+++ b/erts/doc/src/notes.xml
@@ -7,6 +7,10 @@
       <year>2004</year><year>2013</year>
       <holder>Ericsson AB. All Rights Reserved.</holder>
     </copyright>
+    <copyright>
+      <year>2015</year>
+      <holder>Basho Technologies. All Rights Reserved.</holder>
+    </copyright>
     <legalnotice>
       The contents of this file are subject to the Erlang Public License,
       Version 1.1, (the "License"); you may not use this file except in
@@ -29,6 +33,22 @@
     <file>notes.xml</file>
   </header>
   <p>This document describes the changes made to the ERTS application.</p>
+
+<section><title>Erts 5.10.3-basho10</title>
+
+    <section><title>Improvements and New Features</title>
+      <list>
+        <item>
+          <p>
+            <c>erlang:make_ref/0</c> is changed to use an atomic counter on
+            64-bit platforms.
+          </p>
+          <p>Basho Id: OTP-51</p>
+        </item>
+      </list>
+    </section>
+
+</section>
 
 <section><title>Erts 5.10.3</title>
 

--- a/erts/emulator/beam/erl_lock_check.c
+++ b/erts/emulator/beam/erl_lock_check.c
@@ -2,6 +2,7 @@
  * %CopyrightBegin%
  *
  * Copyright Ericsson AB 2005-2013. All Rights Reserved.
+ * Copyright Basho Technologies 2015. All Rights Reserved.
  *
  * The contents of this file are subject to the Erlang Public License,
  * Version 1.1, (the "License"); you may not use this file except in
@@ -137,7 +138,9 @@ static erts_lc_lock_order_t erts_lock_order[] = {
 #ifdef ERTS_SMP
     {	"sys_msg_q", 				NULL			},
     {	"atom_tab",				NULL			},
+#ifdef  ARCH_32
     {	"make_ref",				NULL			},
+#endif
     {	"misc_op_list_pre_alloc_lock",		"address"		},
     {	"message_pre_alloc_lock",		"address"		},
     {	"ptimer_pre_alloc_lock",		"address",		},

--- a/erts/vsn.mk
+++ b/erts/vsn.mk
@@ -18,7 +18,7 @@
 #
 
 VSN = 5.10.3
-SYSTEM_VSN = R16B02_basho9
+SYSTEM_VSN = R16B02_basho10
 
 # Port number 4365 in 4.2
 # Port number 4366 in 4.3


### PR DESCRIPTION
Increments release version to R16B02_basho10 to indicate code changes.

Basho internal issue OTP-51
