### PR TITLE
Add OS X El Capitan instructions for locating OpenSSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,37 @@ following options are recommended:
 We only support 64-bit platforms, so use `--enable-darwin-64bit` on OS X or
 `--enable-m64-build` on anything else.
 
+######OS X El Capitan Specific
+
+Starting with OS X 10.11, Apple no longer includes the OpenSSL headers in
+their standard location under `/usr/include`.  The supporting runtime
+libraries *are* present, so Erlang/OTP built on OS X 10.10 or earlier will
+run on 10.11, but if you want to build on 10.11, and you haven't already
+taken steps for the OpenSSL headers to be found at `/usr/include/openssl`,
+then the following is the least intrusive approach.
+
+As of this writing, OTP crypto support can be built with a standard Xcode
+7.2 installation on OS X 10.11 by adding the following `./otp_build` or
+`./configure` option:
+
+```
+--with-ssl=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-migrator/sdk/MacOSX.sdk/usr
+```
+
+_**Note:** Apple has deprecated OpenSSL in OS X, so it is unclear whether
+this is a stable strategy or location.  We'll attempt to stay on top of the
+specifics as they evolve, and future Basho releases may include more
+transparent support._ 
+
+
 #####Standard Options
 
 Use `--prefix=/your/install/dir` if you're installing anywhere other than
 the default location of `/usr/local`.
 
 We use crypto, so include `--with-ssl` to force a build failure if the
-necessary files aren't found.
+necessary files aren't found. _Note the specific instructions relating to
+OS X 10.11 (El Capitan) above if you are building on that platform._
 
 Unless you need ODBC ***and*** have installed an appropriate SDK, include
 `--without-odbc`.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ our products suport.
 General information on building and installing Erlang/OTP can be found
 in the [$ERL_TOP/HOWTO/INSTALL.md](HOWTO/INSTALL.md) document.
 
+***These instructions are specific to the Basho R16 release they are included
+with.  Be sure to use the instructions for the release you are building!***
+
 Basho recommends configuring and building using the `otp_build` script found
 in the distribution's base directory. This script supports every reasonable
 option you'd use in production, and ensures that all components are
@@ -87,8 +90,9 @@ a Basho production release, set the following:
 * `ERL_TOP` - The base of the source tree.
 * `CFLAGS` - We recommend `-g -O3`.
   * If you'll *only* be running this build on the system you're building it
-    on (or identical hardware), adding `-march=native` to `CFLAGS` may improve
-    performance.
+    on (or identical hardware), adding `-march=native` to `CFLAGS` _may_
+    improve performance, in some cases significantly.
+* `CXXFLAGS` - Either unset, or generally the same as `CFLAGS`.
 * `LDFLAGS` - Either unset, or generally the same as `CFLAGS`.
 
 Note that the `-g` flag is used to add symbols that may be helpful in
@@ -133,9 +137,12 @@ transparent support._
 Use `--prefix=/your/install/dir` if you're installing anywhere other than
 the default location of `/usr/local`.
 
-We use crypto, so include `--with-ssl` to force a build failure if the
-necessary files aren't found. _Note the specific instructions relating to
-OS X 10.11 (El Capitan) above if you are building on that platform._
+We use crypto, so include `--with-ssl` and confirm that "No usable OpenSSL
+found" does NOT appear in the output of the `configure` stage.
+If it does, refer to [$ERL_TOP/HOWTO/INSTALL.md](HOWTO/INSTALL.md) and/or
+`./configure --help` to provide an appropriate `--with-ssl=PATH` option.
+_Note the specific instructions relating to OS X 10.11 (El Capitan) above
+if you are building on that platform._
 
 Unless you need ODBC ***and*** have installed an appropriate SDK, include
 `--without-odbc`.
@@ -166,6 +173,7 @@ from the `clone` example above.
 $ cd $HOME/basho/otp-16
 $ export ERL_TOP="$(pwd)"
 $ export CFLAGS='-g -O3'
+$ export CXXFLAGS="$CFLAGS"
 $ export LDFLAGS="$CFLAGS"
 $ ./otp_build setup -a --prefix=/opt/basho/otp-16 --enable-m64-build --with-ssl --without-odbc --disable-hipe
 ```


### PR DESCRIPTION
README change only.  Doing this as a PR because the text feels convoluted, suggestions welcome.

Basho issue OTP-57