### PR TITLE
ssl: Do not crash server when client sends unsupported named Elliptic Curves

### DIFF
--- a/lib/ssl/src/ssl_handshake.erl
+++ b/lib/ssl/src/ssl_handshake.erl
@@ -1492,7 +1492,16 @@ dec_hello_extensions(<<?UINT16(?SIGNATURE_ALGORITHMS_EXT), ?UINT16(Len),
 dec_hello_extensions(<<?UINT16(?ELLIPTIC_CURVES_EXT), ?UINT16(Len),
 		       ExtData:Len/binary, Rest/binary>>, Acc) ->
     <<?UINT16(_), EllipticCurveList/binary>> = ExtData,
-    EllipticCurves = [tls_v1:enum_to_oid(X) || <<X:16>> <= EllipticCurveList],
+    %% Ignore unknown curves
+    Pick = fun(Enum) ->
+		   case tls_v1:enum_to_oid(Enum) of
+		       undefined ->
+			   false;
+		       Oid ->
+			   {true, Oid}
+		   end
+	   end,
+    EllipticCurves = lists:filtermap(Pick, [ECC || <<ECC:16>> <= EllipticCurveList]),
     dec_hello_extensions(Rest, Acc#hello_extensions{elliptic_curves =
 							#elliptic_curves{elliptic_curve_list =
 									     EllipticCurves}});

--- a/lib/ssl/src/tls_v1.erl
+++ b/lib/ssl/src/tls_v1.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 2007-2013. All Rights Reserved.
+%% Copyright Ericsson AB 2007-2014. All Rights Reserved.
 %%
 %% The contents of this file are subject to the Erlang Public License,
 %% Version 1.1, (the "License"); you may not use this file except in
@@ -425,7 +425,9 @@ enum_to_oid(21) -> ?secp224r1;
 enum_to_oid(22) -> ?secp256k1;
 enum_to_oid(23) -> ?secp256r1;
 enum_to_oid(24) -> ?secp384r1;
-enum_to_oid(25) -> ?secp521r1.
+enum_to_oid(25) -> ?secp521r1;
+enum_to_oid(_) ->
+    undefined.
 
 sufficent_ec_support() ->
     CryptoSupport = crypto:supports(),


### PR DESCRIPTION
When TLS client sends Supported Elliptic Curves Client Hello Extension
the server shall select a curve supported by both sides or refuse to
negotiate the use of an ECC cipher suite.

Backport of ebfd862 to R16B02_basho10.
Signed-off-by: Magnus Kessler <mkessler@basho.com>

This is the minimum patch allowing the handshake to complete when newer TLS clients send *Client Hello* packets containing named elliptic curves unknown to Erlang's TLS handshake code.

We have seen several clients suddenly fail when the OS packages were updated to recent OpenSSL versions. Applying this patch guards against sudden breakage. All other workarounds are purely client side and either require setting cipher suites completely devoid of ciphers with EC key exchange, or with openssl-1.0.2+, restricting the named elliptic curves sent in the handshake to only contain the curves known to OTP-16.