### PR TITLE
Backport ECC handshake fix from SSL 5.3.4

### DIFF
--- a/lib/ssl/doc/src/notes.xml
+++ b/lib/ssl/doc/src/notes.xml
@@ -7,6 +7,10 @@
       <year>1999</year><year>2013</year>
       <holder>Ericsson AB. All Rights Reserved.</holder>
     </copyright>
+    <copyright>
+      <year>2013</year><year>2016</year>
+      <holder>Basho Technologies, Inc.</holder>
+    </copyright>
     <legalnotice>
       The contents of this file are subject to the Erlang Public License,
       Version 1.1, (the "License"); you may not use this file except in
@@ -25,6 +29,25 @@
     <file>notes.xml</file>
   </header>
   <p>This document describes the changes made to the SSL application.</p>
+
+<section><title>SSL 5.3.1-basho10</title>
+
+    <section><title>Fixed Bugs and Malfunctions</title>
+      <list>
+        <item>
+          <p>
+            Backport handshake fix from SSL 5.3.4 (OTP-17).
+          </p>
+          <p>
+            Server now ignores client ECC curves that it does not support
+            instead of crashing.
+          </p>
+          <p>Own Id: OTP-11780</p>
+        </item>
+      </list>
+    </section>
+
+</section>
 
 <section><title>SSL 5.3.1-basho9</title>
 

--- a/lib/ssl/src/tls_v1.erl
+++ b/lib/ssl/src/tls_v1.erl
@@ -1,7 +1,7 @@
 %%
 %% %CopyrightBegin%
 %%
-%% Copyright Ericsson AB 2007-2013. All Rights Reserved.
+%% Copyright Ericsson AB 2007-2014. All Rights Reserved.
 %%
 %% The contents of this file are subject to the Erlang Public License,
 %% Version 1.1, (the "License"); you may not use this file except in
@@ -425,7 +425,9 @@ enum_to_oid(21) -> ?secp224r1;
 enum_to_oid(22) -> ?secp256k1;
 enum_to_oid(23) -> ?secp256r1;
 enum_to_oid(24) -> ?secp384r1;
-enum_to_oid(25) -> ?secp521r1.
+enum_to_oid(25) -> ?secp521r1;
+enum_to_oid(_) ->
+    undefined.
 
 sufficent_ec_support() ->
     CryptoSupport = crypto:supports(),


### PR DESCRIPTION
Let TLS server ignore client ECC curves that it does not support instead of crashing.

This is functionally equivalent to the fix for OTP-11780 added in OTP 17.