### PR TITLE
Make ct_slave:start work on non-fqdn hosts

### DIFF
--- a/lib/common_test/src/ct_slave.erl
+++ b/lib/common_test/src/ct_slave.erl
@@ -306,7 +306,13 @@ is_started(ENode) ->
 
 % make a Erlang node name from name and hostname
 enodename(Host, Node) ->
-    list_to_atom(atom_to_list(Node)++"@"++atom_to_list(Host)).
+    Node_s = atom_to_list(Node),
+    case string:chr(Node_s, $@) of
+        0 ->
+            list_to_atom(Node_s++"@"++atom_to_list(Host));
+        _ ->
+            Node
+    end.
 
 % performs actual start of the "slave" node
 do_start(Host, Node, Options) ->


### PR DESCRIPTION
While working on cluster upgrade-downgrade test harness (https://github.com/basho/riak_test/pull/1091), I found myself needing to issue queries with two different versions of Erlang client. This could easily be accomplished by starting a separate node, with a custom `"-pa"` parameter, and executing `rpc:call` on it. There are OTP facilities in common_test just for that.

However, I found that `ct_slave:start/2` was acting weirdly, producing node names like `aaa@localhost@127.0.0.1`, and failing to figure that 127.0.0.1 and localhost (and whatever I call my box in /etc/hosts) are one and the same host. The issue(s) being reported here have been known for some time: http://erlang.org/pipermail/erlang-questions/2016-February/087632.html.

This PR fixes those two issues. (Also, there's a third commit which reindents parts of otherwise uninvolved code, and which I will be happy to drop to reduce the diff size.)