### PR TITLE
Backport of OTP PR 1501

### DIFF
--- a/erts/configure.in
+++ b/erts/configure.in
@@ -3649,7 +3649,7 @@ case $host_os in
 	darwin*)
 		# Mach-O linker: a shared lib and a loadable
 		# object file is not the same thing.
-		DED_LDFLAGS="-bundle -flat_namespace -undefined suppress"
+		DED_LDFLAGS="-bundle -bundle_loader ${ERL_TOP}/bin/$host/beam.smp"
 		case $ARCH in
 			amd64)
 				DED_LDFLAGS="-m64 $DED_LDFLAGS"


### PR DESCRIPTION
This PR is a back port of:

https://github.com/erlang/otp/pull/1501/files

which addresses a SEGV on NIFS with flat namespaces (e.g., crypto).

For example, the following code will SEGV the BEAM with the following code:

`crypto:rand_uniform(0, 100).`

and stack trace:

```
Thread 74 Crashed:
0   beam.smp                      	0x000000001e990ba5 erts_alcu_free_thr_pref + 389 (erl_alloc_util.c:5011)
1   libcrypto.0.9.8.dylib         	0x00007fff67c713f5 CRYPTO_free + 37
2   libcrypto.0.9.8.dylib         	0x00007fff67c519f6 bn_expand2 + 54
3   libcrypto.0.9.8.dylib         	0x00007fff67c7f7e0 BN_uadd + 64
4   libcrypto.0.9.8.dylib         	0x00007fff67c7f4b5 BN_add + 37
5   crypto.so                     	0x00000000229c4de2 rand_uniform_nif + 258 (crypto.c:1779)
6   beam.smp                      	0x000000001eb43f73 process_main + 40323 (beam_emu.c:3324)
7   beam.smp                      	0x000000001e9ef401 sched_thread_func + 481 (erl_process.c:5803)
8   beam.smp                      	0x000000001ebd2b42 thr_wrapper + 146 (ethread.c:106)
9   libsystem_pthread.dylib       	0x00007fff69bde661 _pthread_body + 340
10  libsystem_pthread.dylib       	0x00007fff69bde50d _pthread_start + 377
11  libsystem_pthread.dylib       	0x00007fff69bddbf9 thread_start + 13
```
